### PR TITLE
Leverage built-in validation highlighting.

### DIFF
--- a/dist/jspm-config.js
+++ b/dist/jspm-config.js
@@ -51,6 +51,7 @@ System.config({
     "stripe-checkout": "https://proxy.zoltu.io/stripe/checkout.js",
     "typescript": "npm:typescript@1.6.2",
     "underscore": "npm:underscore@1.8.3",
+    "validation-hint": "local-component/validation-hint",
     "github:aurelia/binding@0.9.1": {
       "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.10.1",
       "aurelia-metadata": "github:aurelia/metadata@0.8.0",

--- a/dist/source/components/validation-hint.ts
+++ b/dist/source/components/validation-hint.ts
@@ -1,0 +1,16 @@
+import {inject, customAttribute} from 'aurelia-framework';
+
+@customAttribute("validation-hint")
+@inject(Element)
+export class ValidationHint {
+	private value: string;
+
+	constructor(private element: Element) {
+	}
+
+	valueChanged(newValue: string) {
+		if (newValue) {
+			this.element.setAttribute("validate", newValue);
+		}
+	}
+}

--- a/dist/source/repo-creator/enter-replacements.html
+++ b/dist/source/repo-creator/enter-replacements.html
@@ -2,6 +2,7 @@
 	<require from="./enter-replacements.css"></require>
 	<require from="progress-modal"></require>
 	<require from="complete-modal"></require>
+	<require from="validation-hint"></require>
 
 	<progress-modal title="Creating Repository..." id="create-modal" progress-modal.ref="progressModal"></progress-modal>
 	<complete-modal complete-modal.ref="completeModal"></complete-modal>
@@ -16,18 +17,15 @@
 		<div style="text-align:center;" if.bind="!replacements">
 			<i class="fa fa-spinner fa-spin" style="font-size:15em;color:#40c5e5;"></i><br/><br/>Finding Replacements...
 		</div>
-		<form name="stringForm" validate.bind="validation" if.bind="replacements">
+		<form name="stringForm" validate.bind="validationGroup" if.bind="replacements" submit.delegate="createRepo()">
 			<!------------------- this is for string input ------------------>
-			<div repeat.for="replacement of replacements" class="col-xs-12 col-sm-6 col-lg-4 ${$parent.validation[$index].result.properties.value.isDirty && !$parent.validation[$index].result.properties.value.isValid ? 'has-warning' : ''}">
-				<input  class="string-input" type="text" value.bind="replacement.value" placeholder.bind="replacement.friendlyName" change.delegate="$parent.onChanged()"/>
-				<p class="help-block aurelia-validation-message" show.bind="$parent.validation[$index].result.properties.value.isDirty">
-					${$parent.validation[$index].result.properties.value.message}
-				</p>
+			<div repeat.for="replacement of replacements" class="form-group col-xs-12 col-sm-6 col-lg-4">
+				<input  class="string-input" type="text" value.bind="replacement.value" placeholder.bind="replacement.friendlyName" change.delegate="$parent.onChanged()" validation-hint.bind="'replacements.' + $index + '.value'"/>
 			</div>
 			<!----------- this section is for bottom submit button ---------->
-			<div class="col-xs-12">
+			<div class="form-group col-xs-12">
 				<div style="float:right;">
-					<button class="btn btn-submit" type="submit" click.delegate="createRepo()">CREATE</button>
+					<button class="btn btn-submit" type="submit">CREATE</button>
 				</div>
 			</div>
 		</form>

--- a/dist/tsconfig.json
+++ b/dist/tsconfig.json
@@ -38,6 +38,7 @@
     "files": [
         "./source/about.ts",
         "./source/app.ts",
+        "./source/components/validation-hint.ts",
         "./source/components/nav-bar.ts",
         "./source/components/progress-modal.ts",
         "./source/components/complete-modal.ts",
@@ -74,6 +75,7 @@
         "./jspm_packages/github/aurelia/task-queue@0.7.0/aurelia-task-queue.d.ts",
         "./jspm_packages/github/aurelia/templating-binding@0.15.0/aurelia-templating-binding.d.ts",
         "./jspm_packages/github/aurelia/templating@0.15.3/aurelia-templating.d.ts",
+        "./jspm_packages/github/aurelia/validation@0.3.1/aurelia-validation.d.ts",
         "./jspm_packages/npm/typescript@1.6.2/lib/lib.core.d.ts",
         "./jspm_packages/npm/typescript@1.6.2/lib/lib.core.es6.d.ts",
         "./jspm_packages/npm/typescript@1.6.2/lib/lib.d.ts",


### PR DESCRIPTION
The solution provided here works save for one bug with needing to use a fat arrow function in one place in order to get `this` properly propagated.  There were a couple minor improvements I wanted to make that took me down a pretty long path to realizing that this task was much harder than I expected.  Rather than asking you to make the changes after I already did them, I went ahead and put this PR together to get this branch aligned with what I would like.  Once merged, I'll merge your PR into the main repo and we can close the contract out.

In order to use the built-in validation highlighting stuff we have to add an attribute that will populate the `validate` attribute.  It is a bit of a hack but it gets the job done and allows us to remove the custom highlighting code, instead leveraging the bootstrap view strategy stuff.

Along with this, the validation now maps to all of the items without having to store the `ValidationGroups` separately or iterate over them when running `validate`.  This provides a minor improvement in readability and leverages Aurelia a bit more.
